### PR TITLE
Fix website crash when project index exceeds Projects.length

### DIFF
--- a/src/components/ProjectsCard/Projectshow.jsx
+++ b/src/components/ProjectsCard/Projectshow.jsx
@@ -1,6 +1,6 @@
 import "./Projectsshow.scss";
-import { useParams } from "react-router-dom";
-import { useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { useState, useEffect } from "react";
 import Projects from "/public/projects.json";
 import { FaHtml5, FaNodeJs, FaReact, FaTools } from "react-icons/fa";
 import {
@@ -18,12 +18,9 @@ import { ImCss3 } from "react-icons/im";
 import { DiGit, DiJava, DiJavascript1 } from "react-icons/di";
 
 const ProjectsShow = () => {
+  const navigate = useNavigate();
   const { projectID } = useParams();
-  const [cardInfo] = useState(
-    Projects.filter((e, i) => {
-      return i === parseInt(projectID);
-    })
-  );
+  const [cardInfo, setCardInfo] = useState(null);
 
   const logos = {
     NodeJS: <FaNodeJs />,
@@ -48,33 +45,59 @@ const ProjectsShow = () => {
     Prisma: <SiPrisma />,
   };
 
+  // console.log(typeof(projectID))
+  useEffect(() => {
+    try {
+      const projectIdInt = parseInt(projectID);
+      if (!isNaN(projectIdInt) && projectIdInt >= 0 && projectIdInt < Projects.length) {
+        const [info] = Projects.filter((e, i) => i === projectIdInt);
+        if (info) {
+          setCardInfo(info);
+        } else {
+          console.error("No such project exist");
+          navigate("/projects");
+        }
+      } else {
+        console.error("No such project exist");
+        navigate("/projects");
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }, [projectID, navigate]);
+
+  // console.log(cardInfo)
+  if (!cardInfo) {
+    return null;
+  }
+
   return (
     <>
       <div className="projectshow-container">
         <div className="projectsshow-project-title">
           <div className="project-name">
-            <h3>{cardInfo[0].title}</h3>
+            <h3>{cardInfo.title}</h3>
             <div
               className="project-status"
               style={{
                 backgroundColor: cardInfo.Status === "Live" ? "#4a90e2" : "#3CBA54",
               }}
             >
-              {cardInfo[0].Status}
+              {cardInfo.Status}
             </div>
           </div>
           <div className="project-image">
-            <img src={cardInfo[0].logo} alt="logo" />
+            <img src={cardInfo.logo} alt="logo" />
           </div>
         </div>
         <div className="projectshow-project-description">
           <h3>Description</h3>
-          <p>{cardInfo[0].description}</p>
+          <p>{cardInfo.description}</p>
         </div>
         <div className="projectshow-techstack">
           <h4>Tech Stack</h4>
           <div className="projects-stacks">
-            {cardInfo[0].techStack.map((tech) => {
+            {cardInfo.techStack.map((tech) => {
               return (
                 <div className="tech" key={tech}>
                   {/* <img src={} alt="" /> */}
@@ -90,7 +113,7 @@ const ProjectsShow = () => {
           <div className="mentors">
             <h4>Mentors</h4>
             <div className="mentor-list">
-              {cardInfo[0].mentors.map((ment) => {
+              {cardInfo.mentors.map((ment) => {
                 return <ul key={ment}>{ment}</ul>;
               })}
             </div>
@@ -98,7 +121,7 @@ const ProjectsShow = () => {
           <div className="contributors">
             <h4>Contributors</h4>
             <div className="contributor-list">
-              {cardInfo[0].contributors.map((cont) => {
+              {cardInfo.contributors.map((cont) => {
                 return <ul key={cont}>{cont}</ul>;
               })}
             </div>


### PR DESCRIPTION
**BUG:**

- In current build if a user goes to /projects/[>9] the whole website crashes
- the conditional rendering of cardinfo.status's background was not working as [0] was missing.

**FIX:**

- Now, if a user goes to /projects/[>9] the website redirects him to /projects
- bg conditional rendering fixed